### PR TITLE
Support passing both URL and collection name to constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 ## Node
+.env
 
 #npm5
 package-lock.json
@@ -22,9 +23,6 @@ coverage
 
 # nyc test coverage
 .nyc_output
-
-# Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
-.grunt
 
 # node-waf configuration
 .lock-wscript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyv/mongo",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "MongoDB storage adapter for Keyv",
   "main": "src/index.js",
   "scripts": {
@@ -42,11 +42,11 @@
     "pify": "3.0.0"
   },
   "devDependencies": {
+    "@keyv/test-suite": "*",
     "ava": "^0.25.0",
     "coveralls": "^3.0.0",
     "eslint-config-xo-lukechilds": "^1.0.0",
     "keyv": "*",
-    "@keyv/test-suite": "*",
     "nyc": "^11.0.3",
     "requirable": "^1.0.1",
     "this": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyv/mongo",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "MongoDB storage adapter for Keyv",
   "main": "src/index.js",
   "scripts": {
@@ -45,6 +45,7 @@
     "@keyv/test-suite": "*",
     "ava": "^0.25.0",
     "coveralls": "^3.0.0",
+    "dotenv": "^6.2.0",
     "eslint-config-xo-lukechilds": "^1.0.0",
     "keyv": "*",
     "nyc": "^11.0.3",

--- a/src/index.js
+++ b/src/index.js
@@ -5,20 +5,20 @@ const mongojs = require('mongojs');
 const pify = require('pify');
 
 class KeyvMongo extends EventEmitter {
-	constructor(opts) {
+	constructor(url, opts) {
 		super();
 		this.ttlSupport = false;
-		opts = opts || {};
-		if (typeof opts === 'string') {
-			opts = { url: opts };
+		url = url || {};
+		if (typeof url === 'string') {
+			url = { url };
 		}
-		if (opts.uri) {
-			opts = Object.assign({ url: opts.uri }, opts);
+		if (url.uri) {
+			url = Object.assign({ url: url.uri }, url);
 		}
 		this.opts = Object.assign({
 			url: 'mongodb://127.0.0.1:27017',
 			collection: 'keyv'
-		}, opts);
+		}, url, opts);
 		this.db = mongojs(this.opts.url);
 
 		const collection = this.db.collection(this.opts.collection);

--- a/test/test.js
+++ b/test/test.js
@@ -16,6 +16,14 @@ test('Collection option merges into default options', t => {
 	});
 });
 
+test('Collection option merges into default options if URL is passed', t => {
+	const store = new KeyvMongo('mongodb://127.0.0.1:27017', { collection: 'foo' });
+	t.deepEqual(store.opts, {
+		url: 'mongodb://127.0.0.1:27017',
+		collection: 'foo'
+	});
+});
+
 test('.delete() with no args doesn\'t empty the collection', async t => {
 	const store = new KeyvMongo('foo'); // Make sure we don't actually connect
 	t.false(await store.delete());

--- a/test/test.js
+++ b/test/test.js
@@ -1,11 +1,14 @@
+import 'dotenv/config'; // eslint-disable-line import/no-unassigned-import
 import test from 'ava';
 import keyvTestSuite, { keyvOfficialTests } from '@keyv/test-suite';
 import Keyv from 'keyv';
 import KeyvMongo from 'this';
 
-keyvOfficialTests(test, Keyv, 'mongodb://127.0.0.1:27017', 'mongodb://127.0.0.1:1234');
+const mongoURL = process.env.MONGO_URL || 'mongodb://127.0.0.1:27017';
 
-const store = () => new KeyvMongo();
+keyvOfficialTests(test, Keyv, mongoURL, 'mongodb://127.0.0.1:1234');
+
+const store = () => new KeyvMongo(mongoURL);
 keyvTestSuite(test, Keyv, store);
 
 test('Collection option merges into default options', t => {
@@ -17,9 +20,9 @@ test('Collection option merges into default options', t => {
 });
 
 test('Collection option merges into default options if URL is passed', t => {
-	const store = new KeyvMongo('mongodb://127.0.0.1:27017', { collection: 'foo' });
+	const store = new KeyvMongo(mongoURL, { collection: 'foo' });
 	t.deepEqual(store.opts, {
-		url: 'mongodb://127.0.0.1:27017',
+		url: mongoURL,
 		collection: 'foo'
 	});
 });


### PR DESCRIPTION
The README gave this example,

> const keyv = new Keyv('mongodb://user:pass@localhost:27017/dbname', { collection: 'cache' });

which didn't actually set the collection name.