### PR TITLE
Drop (failing) test for Node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 node_js:
+  - 'node'
+  - '10'
   - '8'
   - '6'
-  - '4'
 services:
   - mongodb
 script: npm test


### PR DESCRIPTION
Was [failing anyway](https://travis-ci.org/lukechilds/keyv-mongo/builds/472530496), and [Node 4 was end-of-life'd in April](https://github.com/nodejs/Release#end-of-life-releases).

Add instead tests for Node 10 and current.