### PR TITLE
Support get() without param, to retrieve all rows/documents in table/collection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ class KeyvMongo extends EventEmitter {
 			expireAfterSeconds: 0,
 			background: true
 		});
-		this.mongo = ['update', 'findOne', 'remove'].reduce((obj, method) => {
+		this.mongo = ['update', 'find', 'findOne', 'remove'].reduce((obj, method) => {
 			obj[method] = pify(collection[method].bind(collection));
 			return obj;
 		}, {});
@@ -39,6 +39,15 @@ class KeyvMongo extends EventEmitter {
 	}
 
 	get(key) {
+        // return all documents if no key is provided
+        if (!key) {
+            return this.mongo.find()
+                .then(
+                    docs => docs.map(doc => doc === null ? undefined : doc.value)
+                );
+        }
+
+        // if a key is provided, return only the matching document
 		return this.mongo.findOne({ key })
 			.then(doc => {
 				if (doc === null) {


### PR DESCRIPTION
Extends the enhancement made in this PR:
https://github.com/lukechilds/keyv/pull/86

- db.get(key) returns a specific document.
- db.get() returns all documents.